### PR TITLE
Updates for getting vagrant up and running

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
-source "http://api.berkshelf.com"
+site :opscode
+chef_api :config
 
 metadata

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,20 +9,17 @@ Vagrant.configure("2") do |config|
   config.vm.box = "opscode_ubuntu-12.04_provisionerless"
   config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
 
-  config.vm.network :private_network, ip: "33.33.33.10"
-  config.vm.network :forwarded_port, guest: 80, host: 8084
-
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 1024]
   end
-
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
 
   config.berkshelf.enabled = true
   config.omnibus.chef_version = :latest
 
   config.vm.define :client do |v|
+    v.vm.network :private_network, ip: "33.33.33.10"
+    v.vm.network :forwarded_port, guest: 80, host: 8084
+
     v.vm.provision :chef_solo do |chef|
       chef.run_list = [
         "recipe[berkshelf::default]"
@@ -31,6 +28,9 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define :api_server do |v|
+    v.vm.network :private_network, ip: "33.33.33.11"
+    v.vm.network :forwarded_port, guest: 80, host: 8085
+
     v.vm.provision :chef_solo do |chef|
       chef.json = {
         berkshelf: {

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -19,7 +19,7 @@
 
 include_attribute "berkshelf::default"
 
-default[:berkshelf][:api][:version]        = "0.1.0"
+default[:berkshelf][:api][:version]        = "1.0.0"
 default[:berkshelf][:api][:port]           = 26200
 default[:berkshelf][:api][:host]           = node[:fqdn]
 default[:berkshelf][:api][:home]           = "#{node[:berkshelf][:home]}/api-server"

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -29,6 +29,5 @@ default[:berkshelf][:api][:git_revision]   = "HEAD"
 default[:berkshelf][:api][:bin_path]       = "berks-api"
 default[:berkshelf][:api][:config_path]    = "#{node[:berkshelf][:api][:home]}/config.json"
 default[:berkshelf][:api][:log_min]        = 10
-default[:berkshelf][:api][:config]         = {
-  home_path: node[:berkshelf][:api][:home]
-}
+default[:berkshelf][:api][:config][:home_path] = node[:berkshelf][:api][:home]
+

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -28,6 +28,7 @@ default[:berkshelf][:api][:git_repo]       = "https://github.com/RiotGames/berks
 default[:berkshelf][:api][:git_revision]   = "HEAD"
 default[:berkshelf][:api][:bin_path]       = "berks-api"
 default[:berkshelf][:api][:config_path]    = "#{node[:berkshelf][:api][:home]}/config.json"
+default[:berkshelf][:api][:log_min]        = 10
 default[:berkshelf][:api][:config]         = {
   home_path: node[:berkshelf][:api][:home]
 }

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -30,4 +30,3 @@ default[:berkshelf][:api][:bin_path]       = "berks-api"
 default[:berkshelf][:api][:config_path]    = "#{node[:berkshelf][:api][:home]}/config.json"
 default[:berkshelf][:api][:log_min]        = 10
 default[:berkshelf][:api][:config][:home_path] = node[:berkshelf][:api][:home]
-

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.2'
 
 supports 'ubuntu'
+supports 'centos'
 
 depends 'runit'
 depends 'rbenv', '>= 1.5.0'

--- a/recipes/api_server.rb
+++ b/recipes/api_server.rb
@@ -68,4 +68,7 @@ include_recipe "runit"
 package "libarchive12"
 package "libarchive-dev"
 
-runit_service "berks-api"
+runit_service "berks-api" do
+  default_logger true
+  log_min node[:berkshelf][:api][:log_min]
+end

--- a/recipes/api_server.rb
+++ b/recipes/api_server.rb
@@ -60,13 +60,19 @@ end
 directory node[:berkshelf][:api][:home]
 
 file node[:berkshelf][:api][:config_path] do
-  content JSON.generate(node[:berkshelf][:api][:config])
+  content JSON.generate(node[:berkshelf][:api][:config].to_hash)
 end
 
 include_recipe "runit"
 
-package "libarchive12"
-package "libarchive-dev"
+case node[:platform_family]
+when "debian"
+  package "libarchive12"
+  package "libarchive-dev"
+when "rhel"
+  package "libarchive"
+  package "libarchive-devel"
+end
 
 runit_service "berks-api" do
   default_logger true

--- a/templates/default/sv-berks-api-run.erb
+++ b/templates/default/sv-berks-api-run.erb
@@ -3,6 +3,7 @@
 export RBENV_ROOT=<%= node[:rbenv][:root] %>
 export RBENV_VERSION=<%= node[:berkshelf][:ruby_version] %>
 export PATH=<%= node[:rbenv][:root] %>/shims:$PATH
+export LANG=en_US.UTF-8
 
 exec 2>&1
 exec <%= node[:berkshelf][:api][:bin_path] %> -p <%= node[:berkshelf][:api][:port] %> -c <%= node[:berkshelf][:api][:config_path] %>


### PR DESCRIPTION
Had to make a few changes to get Vagrant up to work and succeed here.
- Berkshelf 3 isn't out yet, so use the 2.0.0 syntax
- Remove that pesky ssh config in a Vagrantfile because it is no longer supported by Vagrant
- Ports were clobbering each other, so to start both Vagrantfile VMs up at the same time, move the config inside each vm configure block
- Add a UTF-8 declaration to the runit script because of a weird `Encoding::InvalidByteSequenceError: "\xE2" on US-ASCII` exception when consuming cookbook's metadata.
