### PR TITLE
JSON.generate fails if it is passed a Chef::Node::Attribute instance. 

### DIFF
--- a/recipes/api_server.rb
+++ b/recipes/api_server.rb
@@ -60,7 +60,7 @@ end
 directory node[:berkshelf][:api][:home]
 
 file node[:berkshelf][:api][:config_path] do
-  content JSON.generate(node[:berkshelf][:api][:config])
+  content JSON.generate(node[:berkshelf][:api][:config].to_hash)
 end
 
 include_recipe "runit"


### PR DESCRIPTION
Call #to_hash to ensure it always receives a hash.
