### PR TITLE
Support varying libarchive package names in Ubuntu

### DIFF
--- a/recipes/api_server.rb
+++ b/recipes/api_server.rb
@@ -69,7 +69,7 @@ if platform_family?("rhel")
   package "libarchive"
   package "libarchive-devel"
 else
-  package "libarchive12"
+  package "libarchive#{node[:platform_version].split('.')[0].chomp('0')}"
   package "libarchive-dev"
 end
 


### PR DESCRIPTION
Apparently the name matches the major Ubuntu version (10.04 => libarchive1, 12.04 => libarchive12, 13.04 => libarchive13) so it was erroring when I tried to run it on 13.10.
